### PR TITLE
Fix #15: don't access rules from foreign sheets

### DIFF
--- a/cjss.js
+++ b/cjss.js
@@ -2,8 +2,12 @@ document.addEventListener('DOMContentLoaded', function (event) {
   function cjss(s) {
     for (var i = 0; i < s.length; ++i) {
       if (s[i].constructor.name === 'CSSImportRule') {
-        var n = s[i].styleSheet.cssRules;
-        cjss(n);
+        try {
+          var n = s[i].styleSheet.cssRules;
+          if (n) cjss(n);
+        } catch (e) {
+          if (e.name !== "SecurityError") throw e;
+        }
       } else if (s[i].constructor.name === 'CSSStyleRule') {
         var js = s[i].style.getPropertyValue('--js');
         var html = s[i].style.getPropertyValue('--html');

--- a/example/component/body.css
+++ b/example/component/body.css
@@ -1,5 +1,6 @@
+@import url('https://fonts.googleapis.com/css?family=Roboto&display=swap');
 body {
-  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+  font-family: Roboto,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
   
   --html:(
     <h1>Hello ${data.name}!</h1>


### PR DESCRIPTION
This stops the crash that occurs when cross-domain CSS imports are used, such as for Google Fonts, by checking whether `.cssRules` exists (Chrome), and whether accessing it is a SecurityError (Firefox).

Please could you check if this crash occurred/is fixed in Edge too?