### PR TITLE
 JS Component scoping without eval.

### DIFF
--- a/cjss.js
+++ b/cjss.js
@@ -52,8 +52,10 @@
           }
 
           // There is a lot of room for optimization here.
-          for (let n = 0; n < elements.length; n++) {
-            eval(js.replace(/this/g, `document.querySelectorAll('${ selector }')[${ n }]`));
+          // for (let n = 0; n < elements.length; n++) {
+          for (let element of elements) {
+            const fn = new Function(js);
+            fn.call(element);
           }
         }
       }

--- a/cjss.js
+++ b/cjss.js
@@ -51,8 +51,6 @@
             continue;
           }
 
-          // There is a lot of room for optimization here.
-          // for (let n = 0; n < elements.length; n++) {
           for (let element of elements) {
             const fn = new Function(js);
             fn.call(element);


### PR DESCRIPTION
JS component scoping is now done with `new Function(js).call(element)` instead of eval.
This is not only way more elegant but a lot safer since the previous implementation would also replace "this" in strings and comments.