### PR TITLE
Prepare functions instead of using safeEval

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ You can add data to your project. Probably useful for something. Do it using the
 ```css
 nav {
   --data:(
-    name: ['one', 'two', 'three'],
-    link: ['#one', '#two', '#three'],
+    name: ["one", "two", "three"],
+    link: ["#one", "#two", "#three"],
   );
   --html:(
     <a class="item" href="${data.link[0]}">${data.name[0]}</a>

--- a/cjss.js
+++ b/cjss.js
@@ -20,7 +20,11 @@
    * @returns {CSSRuleList} The rules of this stylesheet.
    */
   function ruleList(styleSheet) {
-    return styleSheet.rules || styleSheet.cssRules;
+    try {
+      return styleSheet.rules || styleSheet.cssRules;
+    } catch (e) {
+      if (e.name !== "SecurityError") throw e;
+    }
   }
 
   /**
@@ -44,10 +48,11 @@
    * Runs CJSS rules - CSS rules with the special properties `--html`,
    * `--js` and `--data`.
    * 
-   * @param {CSSRuleList} rules An array-like object of CJSS rules.
+   * @param {CSSStyleSheet} rules The stylesheet from which to run the rules.
    **/
-  function cjss(rules) {
-    for (const rule of rules) {
+  function cjss(styleSheet) {
+    const rules = ruleList(styleSheet) || [];
+    for (const rule of rules || []) {
 
       // Handle imports recursively
       if (rule instanceof CSSImportRule) {
@@ -87,8 +92,7 @@
    */
   function initialize() {
     for (const sheet of document.styleSheets) {
-      const rules = ruleList(sheet);
-      if (rules) cjss(rules);
+      cjss(sheet);
     }
   }
   

--- a/cjss.js
+++ b/cjss.js
@@ -23,6 +23,16 @@
     return styleSheet.rules || styleSheet.cssRules;
   }
 
+  /**
+   * Convert lazy JavaScript syntax for a JSON object into strict JSON ready
+   * for parsing.
+   * 
+   * In the lazy syntax, trailing commas are allowed, single-quoted strings
+   * are allowed, and object keys do not have to be quoted.
+   *
+   * @param {String} json JSON in JavaScript syntax.
+   * @returns {String} JSON converted to strict syntax.
+   */
   const preprocessJSON = json => `{${json
     .replace(/'([^\\']*(?:(?:(?:\\.))+[^\\']*)*)'/g,(_,str) =>
       `"${str.replace("\\'","'").replace(/((?:[^\\]|^)(?:\\.)*)"/,'$1\\"')}"`

--- a/cjss.js
+++ b/cjss.js
@@ -2,7 +2,7 @@
 (() => {
 
   /**
-   * Get value of a rule's property and remove surrounding parentheses.
+   * Get value of a rule's property and remove surrounding parentheses, if present.
    * @param {CSSStyleRule} rule The CSSStyleRule, which to select from.
    * @param {String} propertyName The name/key which to select.
    * @returns {String} The contents of the given property, or empty if no such
@@ -10,7 +10,7 @@
    **/
   function getPureProperty(rule, propertyName) {
     const raw = rule.style.getPropertyValue(propertyName);
-    return raw.replace(/^\s*\(([\s\S]*)\)\s*$/g,'$1');
+    return raw.trim().replace(/^\(([\s\S]*)\)$/g,'$1');
   }
 
   /**

--- a/cjss.js
+++ b/cjss.js
@@ -48,7 +48,7 @@
 
         const data = rawData ? JSON.parse(`{ ${rawData} }`) : {};
         if (html) {
-          const renderHTML = new Function('yield,data',`return \`${html}\`;`);
+          const renderHTML = new Function('yield,data', `return \`${html}\`;`);
           for (const element of elements) {
             element.innerHTML = renderHTML(element.innerHTML, data);
           }

--- a/cjss.js
+++ b/cjss.js
@@ -46,8 +46,7 @@
         const html = getPureProperty(rule, '--html');
         const rawData = getPureProperty(rule, '--data');
 
-        const data = rawData ? (0, eval)(`({ ${rawData} })`) : {};
-
+        const data = rawData ? JSON.parse(`{ ${rawData} }`) : {};
         if (html) {
           const renderHTML = new Function('yield,data',`return \`${html}\`;`);
           for (const element of elements) {

--- a/example/component/body.css
+++ b/example/component/body.css
@@ -9,6 +9,6 @@ body {
     <nav>Title</nav>
   );
   --data:(
-    name:'world',
+    name: "world",
   );
 }

--- a/example/component/nav.css
+++ b/example/component/nav.css
@@ -1,13 +1,14 @@
 nav {
   --data:(
-    links: ['one', 'two', 'three'],
+    name: ["one", "two", "three"],
+    link: ["#one", "#two", "#three"],
   );
   --html:(
-    <h3>${yield}</h3>
-    <div class="item">${data.links[0]}</div>
-    <div class="item">${data.links[1]}</div>
-    <div class="item">${data.links[2]}</div>
+    <a class="item" href="${data.link[0]}">${data.name[0]}</a>
+    <a class="item" href="${data.link[1]}">${data.name[1]}</a>
+    <a class="item" href="${data.link[2]}">${data.name[2]}</a>
   );
+  --js:(console.log(data));
 }
 
 nav .item {

--- a/example/style.css
+++ b/example/style.css
@@ -4,7 +4,7 @@
 /* Run a script */
 script {
   --data:(
-    say: 'Hello world!'
+    say: "Hello world!"
   );
   --js:(
     console.log(data.say);


### PR DESCRIPTION
As discussed in #7, `eval` is probably not needed in `--data`, and so I have converted this to JSON (backwards-compatible to also support JavaScript syntax of single-quoted strings, non-quoted keys and trailing commas). Elsewhere, I have replaced calls to `safe_eval` with the `Function` constructor, which means each function is only generated once, rather than once per matching element.

I have also changed the way that enclosing parentheses are parsed: instead of blindly discarding the first and last characters, this now only happens if they are actually a pair of parentheses ([`cjss.js:13`](https://github.com/scottkellum/CJSS/compare/master...xsanda:remove-eval?expand=1#diff-2c5aa91cf7acd4b26971b0483d120ee9R13)).