### PR TITLE
Use JSON for data attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ You can add data to your project. Probably useful for something. Do it using the
 ```css
 nav {
   --data:(
-    name: ['one', 'two', 'three'],
-    link: ['#one', '#two', '#three'],
+    "name": ["one", "two", "three"],
+    "link": ["#one", "#two", "#three"]
   );
   --html:(
     <a class="item" href="${data.link[0]}">${data.name[0]}</a>

--- a/example/component/body.css
+++ b/example/component/body.css
@@ -9,6 +9,6 @@ body {
     <nav>Title</nav>
   );
   --data:(
-    name:'world',
+    "name": "world"
   );
 }

--- a/example/component/nav.css
+++ b/example/component/nav.css
@@ -1,13 +1,14 @@
 nav {
   --data:(
-    links: ['one', 'two', 'three'],
+    "name": ["one", "two", "three"],
+    "link": ["#one", "#two", "#three"]
   );
   --html:(
-    <h3>${yield}</h3>
-    <div class="item">${data.links[0]}</div>
-    <div class="item">${data.links[1]}</div>
-    <div class="item">${data.links[2]}</div>
+    <a class="item" href="${data.link[0]}">${data.name[0]}</a>
+    <a class="item" href="${data.link[1]}">${data.name[1]}</a>
+    <a class="item" href="${data.link[2]}">${data.name[2]}</a>
   );
+  --js:(console.log(data));
 }
 
 nav .item {

--- a/example/style.css
+++ b/example/style.css
@@ -4,7 +4,7 @@
 /* Run a script */
 script {
   --data:(
-    say: 'Hello world!'
+    "say": "Hello world!"
   );
   --js:(
     console.log(data.say);

--- a/src/cjss.js
+++ b/src/cjss.js
@@ -22,13 +22,11 @@ export default function cjss(styleSheet) {
       const selector = rule.style.parentRule.selectorText;
       const elements = document.querySelectorAll(selector);
 
-      let js = getPureProperty(rule, '--js');
-      let html = getPureProperty(rule, '--html');
+      const js = getPureProperty(rule, '--js');
+      const html = getPureProperty(rule, '--html');
       let data = getPureProperty(rule, '--data');
 
-      if (data) {
-        data = safeEval(`return ({ ${ data } })`);
-      }
+      data = data ? JSON.parse(`{${data}}`) : {};
 
       if (html) {
         for (let element of elements) {

--- a/src/cjss.js
+++ b/src/cjss.js
@@ -27,7 +27,7 @@ function processRule(rule) {
   }
 
   if (html) {
-    for (let element of elements) {
+    for (const element of elements) {
       try{
         element.innerHTML = safeEval(
           `return (\`${ html }\`)`,
@@ -56,7 +56,7 @@ function processRule(rule) {
         console.error(`of script:\n${js}`);
         return;
       }
-    } else for (let element of elements) {
+    } else for (const element of elements) {
       try {
         safeEval(js, { data }, element);
       } catch (e) {
@@ -77,7 +77,7 @@ function processRule(rule) {
    */
 export default function cjss(styleSheet) {
   const rules = ruleList(styleSheet);
-  if (rules) for (let rule of rules) {
+  if (rules) for (const rule of rules) {
     const ruleName = rule.constructor.name;
 
     // Handle imports (recursive)

--- a/src/cjss.js
+++ b/src/cjss.js
@@ -3,6 +3,43 @@ import safeEval from './safeEval';
 import ruleList from './ruleList';
 
 /**
+ * Run one CJSS rule, handling the properties `--html`, `--js` and `--data`.
+ *
+ * @param {CSSRule} rule The rule to parse.
+ */
+function processRule(rule) {
+  const selector = rule.style.parentRule.selectorText;
+  const elements = document.querySelectorAll(selector);
+
+  const js = getPureProperty(rule, '--js');
+  const html = getPureProperty(rule, '--html');
+  let data = getPureProperty(rule, '--data');
+
+  data = data ? JSON.parse(`{${data}}`) : {};
+
+  if (html) {
+    for (let element of elements) {
+      element.innerHTML = safeEval(
+        `return (\`${ html }\`)`,
+        {
+          data,
+          yield: element.innerHTML
+        },
+        element
+      );
+    }
+  }
+
+  if (js) {
+    if (selector === 'script') {
+      safeEval(js, { data });
+    } else for (let element of elements) {
+      safeEval(js, { data }, element);
+    }
+  }
+}
+
+/**
    * Runs CJSS rules - CSS rules with the special properties `--html`,
    * `--js` and `--data`.
    *
@@ -19,38 +56,7 @@ export default function cjss(styleSheet) {
     }
 
     else if (ruleName === 'CSSStyleRule') {
-      const selector = rule.style.parentRule.selectorText;
-      const elements = document.querySelectorAll(selector);
-
-      const js = getPureProperty(rule, '--js');
-      const html = getPureProperty(rule, '--html');
-      let data = getPureProperty(rule, '--data');
-
-      data = data ? JSON.parse(`{${data}}`) : {};
-
-      if (html) {
-        for (let element of elements) {
-          element.innerHTML = safeEval(
-            `return (\`${ html }\`)`,
-            {
-              data,
-              yield: element.innerHTML
-            },
-            element
-          );
-        }
-      }
-
-      if (js) {
-        if (selector === 'script') {
-          safeEval(js, { data });
-          continue;
-        }
-
-        for (let element of elements) {
-          safeEval(js, { data }, element);
-        }
-      }
+      processRule(rule);
     }
   }
 }

--- a/src/cjss.js
+++ b/src/cjss.js
@@ -20,7 +20,8 @@ function processRule(rule) {
     data = data ? JSON.parse(`{${data}}`) : {};
   } catch (e) {
     if (e instanceof SyntaxError) {
-      console.error(`Invalid JSON found at ${selector}: {\n${data}\n}`);
+      console.error(`CJSS: Invalid JSON found at ${selector}: {${data}}`);
+      console.error(e.message);
       return false;
     } else throw e;
   }
@@ -37,7 +38,9 @@ function processRule(rule) {
           element
         );
       } catch (e) {
-        console.error(e);
+        console.error('CJSS: Error in HTML:', e);
+        console.error(`at selector '${selector}' and element`, element);
+        console.error(`of script:\n${js}`);
         return;
       }
     }
@@ -48,7 +51,7 @@ function processRule(rule) {
       try {
         safeEval(js, { data });
       } catch (e) {
-        console.error('Error in JS:', e);
+        console.error('CJSS: Error in JS:', e);
         console.error(`at selector '${selector}'`);
         console.error(`of script:\n${js}`);
         return;
@@ -57,7 +60,7 @@ function processRule(rule) {
       try {
         safeEval(js, { data }, element);
       } catch (e) {
-        console.error('Error in JS:', e);
+        console.error('CJSS: Error in JS:', e);
         console.error(`at selector '${selector}' and element`, element);
         console.error(`of script:\n${js}`);
         return;

--- a/src/getPureProperty.js
+++ b/src/getPureProperty.js
@@ -1,5 +1,6 @@
 /**
- * Get value of a rule's property and remove surrounding parentheses.
+ * Get value of a rule's property and remove surrounding parentheses, if
+ * present.
  *
  * @param {CSSStyleRule} rule The CSSStyleRule, which to select from.
  * @param {String} propertyName The name/key which to select.
@@ -8,5 +9,7 @@
  **/
 export default function getPureProperty(rule, propertyName) {
   const raw = rule.style.getPropertyValue(propertyName);
-  return raw.trim().slice(1, -1);
+  // If the string starts with '(' and ends with ')', remove those
+  // parentheses.
+  return raw.trim().replace(/^\(([\s\S]*)\)$/g,'$1');
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,9 @@
 import initialize from './initialize';
 import cjss from './cjss';
 
-document.addEventListener('DOMContentLoaded', initialize);
+if (['complete','interactive','loaded'].includes(document.readyState)) {
+  initialize();
+} else document.addEventListener('DOMContentLoaded', initialize);
 
 export default {
   render: cjss  // This can be globally accessed via cjss.render()


### PR DESCRIPTION
As discussed in #7, eval can be avoided in data, and so I have converted this to JSON. This is a breaking change, as JS Under #26, this functionality could be restored once plugins are implemented, with `js()`/`js-expr()` data.

Because this is a breaking change, I have made sure that the error is properly logged to console, and added error handling for HTML and JavaScript too.